### PR TITLE
Add CI workflow for publishing releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,80 @@
+name: CI
+
+on:
+  push:
+    branches: '*'
+    tags: v*
+  pull_request:
+    branches:
+      - master
+
+permissions:
+  contents: write
+
+jobs:
+  build_and_test:
+    name: Build and test for ${{ matrix.os.target }}-${{ matrix.arch }} on ${{ matrix.os.host }}
+    runs-on: ${{ matrix.os.host }}
+    strategy:
+      matrix:
+        arch:
+          - amd64
+          - arm64
+
+        os:
+          - target: darwin
+            host: macOS-latest
+          - target: linux
+            host: ubuntu-latest
+
+        include:
+          - arch: 386
+            os:
+              target: linux
+              host: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+
+      - name: Build
+        run: go build
+        env:
+          GOOS: ${{ matrix.os.target }}
+          GOARCH: ${{ matrix.arch }}
+
+      - name: Test
+        if: matrix.arch == 'amd64'
+        run: ./kubeconsole --help
+
+  release:
+    name: Publish Release
+    needs: build_and_test
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,4 +77,4 @@ jobs:
           version: latest
           args: release --rm-dist
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ build/*
 
 kubeconsole
 completions/
+dist/

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ build/*
 *.snap
 
 kubeconsole
+completions/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,47 @@
+before:
+  hooks:
+    - go mod tidy
+    - ./generate_completions.sh
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+      - 386
+
+checksum:
+  name_template: 'checksums.txt'
+
+snapshot:
+  name_template: "{{ .Tag }}-next"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+
+archives:
+  - files:
+      - README.md
+      - LICENSE
+      - completions/*
+
+brews:
+  - tap:
+      owner: micke
+      name: homebrew-kubeconsole
+    homepage: https://github.com/micke/kubeconsole
+    description: Utility to create temporary REPL pods from deployments
+    license: MIT
+    test: system "#{bin}/kubeconsole", "--help"
+    post_install: |
+      bash_completion.install "completions/{{ .ProjectName }}.bash" => "{{ .ProjectName }}"
+      zsh_completion.install "completions/{{ .ProjectName }}.zsh" => "_{{ .ProjectName }}"
+      fish_completion.install "completions/{{ .ProjectName }}.fish" => "_{{ .ProjectName }}"

--- a/generate_completions.sh
+++ b/generate_completions.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -e
+
+rm -rf completions
+mkdir -p completions
+
+for shell in bash zsh; do
+  go run main.go completion "$shell" > "completions/kubeconsole.$shell"
+done

--- a/generate_completions.sh
+++ b/generate_completions.sh
@@ -5,6 +5,6 @@ set -e
 rm -rf completions
 mkdir -p completions
 
-for shell in bash zsh; do
+for shell in bash zsh fish; do
   go run main.go completion "$shell" > "completions/kubeconsole.$shell"
 done


### PR DESCRIPTION
This sets up two jobs in the CI workflow. One for building and testing, which is run on each push. One for publishing a release, both publishing binaries to this repository and updating the Homebrew formula at https://github.com/micke/homebrew-kubeconsole. The latter doesn't currently work due to a missing GitHub access token. The release job is only run for tags.